### PR TITLE
chore: bump to node 18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3.5.3
 
-      - name: Install node 16
+      - name: Install node 18
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
           cache: npm
 
       - name: Install project modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Install node 16
+      - name: Install node 18
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
           cache: npm
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3.5.3
 
-      - name: Install node 16
+      - name: Install node 18
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
           cache: npm
 
       - name: Install project modules

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "src/repo.js"
   ],
   "engines": {
-    "node": ">= 16.0.0",
-    "npm": ">= 8.0.0"
+    "node": ">= 18.0.0",
+    "npm": ">= 9.0.0"
   },
   "scripts": {
     "lint": "eslint src --ext js",


### PR DESCRIPTION
BREAKING CHANGE: @octokit/graphql 6.x has dropped support for node 16, hence we bump to 18

Signed-off-by: Tomer Figenblat <tomer@tomfi.info>

<!-- markdownlint-disable MD041-->
## Description

> Describe what you did and why.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
