### PR TITLE
ci: security hardening for GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,10 @@ jobs:
     name: Lint project
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install node 18
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # checkout
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
           - auto
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     name: Release package
+    permissions:
+      id-token: write # npm publish
+      contents: write # git tag
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,12 +37,12 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Install node 18
+      - name: Install node 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "18"
-          cache: npm
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Configure git
         run: |
@@ -67,9 +70,7 @@ jobs:
         run: npm ci --production
 
       - name: Publish package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
+        run: npm publish --access=public
 
       - name: Commit and push package modifications
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,10 @@ jobs:
 
       - name: Setup SSH signing
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          echo "${{ secrets.SIGNING_KEY }}" > $RUNNER_TEMP/signing_key
+          chmod 600 $RUNNER_TEMP/signing_key
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey $RUNNER_TEMP/signing_key
           git config commit.gpgsign true
 
       - name: Determine next SemVer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,13 @@ jobs:
     name: Release package
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Install node 18
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
           cache: npm
@@ -57,7 +57,7 @@ jobs:
 
       - name: Determine next SemVer
         id: bumper
-        uses: tomerfi/version-bumper-action@2.0.7
+        uses: tomerfi/version-bumper-action@6892021917fa099d2986fcbf3acc584659af193a # 2.0.7
         with:
           bump: '${{ github.event.inputs.bump }}'
 
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create a release name
         id: release_name
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             var retval = '${{ steps.bumper.outputs.next }}'
@@ -97,7 +97,7 @@ jobs:
 
       - name: Create a release
         id: gh_release
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,17 @@ on:
     inputs:
       title:
         description: "Release title (blank for tag)"
-        required: false
+        type: string
       bump:
         description: "Bump type (major/minor/patch/auto)"
         default: "auto"
         required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - auto
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,14 @@ jobs:
 
       - name: Create a release name
         id: release_name
+        env:
+          TITLE: ${{ github.event.inputs.title }}
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             var retval = '${{ steps.bumper.outputs.next }}'
-            if ('${{ github.event.inputs.title }}') {
-              retval = retval.concat(' - ${{ github.event.inputs.title }}')
+            if (process.env.TITLE) {
+              retval = retval.concat(' - ' + process.env.TITLE)
             }
             core.setOutput('value', retval)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,8 @@ jobs:
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           script: |
-            const repo_name = context.payload.repository.full_name
-            const response = await github.request('POST /repos/' + repo_name + '/releases', {
+            const response = await github.rest.repos.createRelease({
+              ...context.repo,
               tag_name: '${{ steps.bumper.outputs.next }}',
               name: '${{ steps.release_name.outputs.value }}',
               generate_release_notes: true

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -13,7 +13,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: test_run-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -6,8 +6,8 @@ on:
     inputs:
       update_readme:
         description: "Update README?"
-        default: "yes"
-        required: false
+        default: true
+        type: boolean
   push:
     branches:
       - main
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         if: >-
           github.event_name == 'workflow_dispatch' &&
-          github.event.inputs.update_readme == 'yes'
+          github.event.inputs.update_readme == 'true'
         with:
           name: stats-artifact
           path: |
@@ -66,9 +66,9 @@ jobs:
     environment: update-docs
     name: Update README
     needs: test_run
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.update_readme == 'yes'
+      if: >-
+        github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.update_readme == 'true'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: test-run
     name: Test run
+    permissions:
+      contents: read # checkout
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,7 +68,9 @@ jobs:
     environment: update-docs
     name: Update README
     needs: test_run
-      if: >-
+    permissions:
+      contents: write # commit and push to repo
+    if: >-
         github.event_name == 'workflow_dispatch' &&
         github.event.inputs.update_readme == 'true'
     steps:

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -87,11 +87,10 @@ jobs:
 
       - name: Setup SSH signing
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          echo "${{ secrets.SIGNING_KEY }}" > $RUNNER_TEMP/signing_key
+          chmod 600 $RUNNER_TEMP/signing_key
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey $RUNNER_TEMP/signing_key
           git config commit.gpgsign true
 
       - name: Update user block

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -23,10 +23,10 @@ jobs:
     name: Test run
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install node 18
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
           cache: npm
@@ -51,7 +51,7 @@ jobs:
           && printf "\`\`\`\n\n" >> my_repo
 
       - name: Upload statistics artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: >-
           github.event_name == 'workflow_dispatch' &&
           github.event.inputs.update_readme == 'true'
@@ -71,12 +71,12 @@ jobs:
         github.event.inputs.update_readme == 'true'
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Download statistics artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: stats-artifact
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to immutable SHA digests with version comments
- Add explicit permissions blocks to all workflow jobs
- Switch npm publishing to OIDC trusted publishing (Node.js 24 + `--provenance`)
- Move SSH signing keys from `~/.ssh` to `$RUNNER_TEMP`
- Replace raw `github.request` with typed `github.rest.repos.createRelease`
- Fix concurrency block syntax in `lint.yml`
- Add explicit type declarations to workflow inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD workflow security by restricting permissions and pinning build tools to specific versions for improved supply-chain security.
  * Updated Node.js runtime from version 18 to 24 in release pipeline.
  * Improved release signing and publishing configurations for greater stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TomerFi/github-viewer-stats/pull/286)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->